### PR TITLE
Update AlwaysInstallElevated Registry Keys Check

### DIFF
--- a/chaps.ps1
+++ b/chaps.ps1
@@ -234,6 +234,7 @@ Catch{
 <#
 Resources:
 Windows Privilege Escalation Fundamentals: http://www.fuzzysecurity.com/tutorials/16.html
+Abusing MSI's Elevated Privileges: https://www.greyhathacker.net/?p=185
 #>
 $inf_str + "Checking if users can install software as NT AUTHORITY\SYSTEM" | Tee-Object -FilePath $out_file -Append
 Try{
@@ -244,13 +245,13 @@ Try{
         $ressysele = $null;
     }
     Try{
-        $resusrele = Get-ItemProperty -path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated' -ErrorAction stop
+        $resusrele = Get-ItemProperty -path 'HKCU:\SOFTWARE\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated' -ErrorAction stop
     }
     Catch{
         $resusrele = $null;
     }
 
-    if ($ressysele -or $resusrele){
+    if ($ressysele -and $resusrele){
             $neg_str + "Users can install software as NT AUTHORITY\SYSTEM." | Tee-Object -FilePath $out_file -Append
     } else {
             $pos_str + "Users cannot install software as NT AUTHORITY\SYSTEM." | Tee-Object -FilePath $out_file -Append


### PR DESCRIPTION
The FuzzySecurity link referenced the GreyHatHacker post, which says that both the HKCU and HKLM registry keys must be set for the vulnerability to be present.  Currently both the ressysele and resusrele variables check the HKLM, so the resusrele needs to be updated to check the HKCU element. Then the if statement is updated to check if both registry keys exist.